### PR TITLE
Enable jobs for WeTransfer

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -92,3 +92,4 @@
   twitter: https://twitter.com/WeTransfer
   facebook: https://www.facebook.com/WeTransfer/
   level: bronze
+  has_jobs: true


### PR DESCRIPTION
We forgot to add the `has_jobs` config parameter for WeTransfer.