### PR TITLE
Fix broken link to MeisterLabs jobs page

### DIFF
--- a/meister.html
+++ b/meister.html
@@ -251,7 +251,7 @@ layout: default
                 </p>
 
                 <p style="font-weight: 600;">
-                    Are you ready to come on board? <a href=”https://www.meisterlabs.com/jobs/” target="_blank">Apply
+                    Are you ready to come on board? <a href="https://www.meisterlabs.com/jobs/" target="_blank">Apply
                     now</a>.
                 </p>
 


### PR DESCRIPTION
The quotes used are not interpreted as such by browsers, resulting in 
```
<a href="”https://www.meisterlabs.com/jobs/”" target="_blank">Apply now</a>
```